### PR TITLE
Update to return integer for Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "illuminate/console": "5.6.*|5.7.*|5.8.*|^6.0|^7.0",
-        "illuminate/support": "5.6.*|5.7.*|5.8.*|^6.0|^7.0"
+        "php": "^7.2.5",
+        "illuminate/console": "^7.0",
+        "illuminate/support": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/SummaryCommand.php
+++ b/src/SummaryCommand.php
@@ -49,12 +49,14 @@ class SummaryCommand extends ListCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->getOption('format') === static::FORMAT && ! $input->getOption('raw')) {
             $this->container[DescriberContract::class]->describe($this->getApplication(), $output);
-        } else {
-            parent::execute($input, $output);
+
+            return 0;
         }
+
+        return parent::execute($input, $output);
     }
 }


### PR DESCRIPTION
Symfony Console v5 now expects the `execute()` method to return an integer for the status code.

This is enforced by the following code:
https://github.com/symfony/console/blob/master/Command/Command.php#L255-L259

I'm not sure if the return type hint should be removed to match [the `Command execute()` method](https://github.com/symfony/console/blob/master/Command/Command.php#L159), but I left it for now.