### PR TITLE
Remove duplicates when using alias commands

### DIFF
--- a/src/Describer.php
+++ b/src/Describer.php
@@ -94,6 +94,8 @@ class Describer implements DescriberContract
             $hasWildcardMatch = $hide->contains($nameParts[0].':*');
 
             return ! $hasExactMatch && ! $hasWildcardMatch;
+        })->unique(function ($command) {
+            return $command->getName();
         })->groupBy(function ($command) {
             $nameParts = explode(':', $name = $command->getName());
             $this->width = max($this->width, mb_strlen($name));
@@ -110,9 +112,10 @@ class Describer implements DescriberContract
 
             foreach ($commands as $command) {
                 $output->write(sprintf(
-                    "  <fg=green>%s</>%s%s\n",
+                    "  <fg=green>%s</>%s%s%s\n",
                     $command->getName(),
                     str_repeat(' ', $this->width - mb_strlen($command->getName()) + 1),
+                    $command->getAliases() ? '<fg=cyan>[</>'.implode('|', $command->getAliases()).'<fg=cyan>]</> ' : '',
                     $command->getDescription()
                 ));
             }


### PR DESCRIPTION
### Issue

When creating aliases for commands using `setAliases()` the `./application` currently lists duplicate commands instead of listing aliases. This would fix https://github.com/laravel-zero/laravel-zero/issues/310.

### Changes

This PR combines duplicates, and lists aliases for commands.

### Example

Command `projects` with alias `p`.

#### Current

```console
$ ./application

  Application  unreleased

  USAGE: application <command> [options] [arguments]

  projects     List all running projects
  projects     List all running projects

  app:build    Build a single file executable
  app:install  Install optional components
  app:rename   Set the application name

  make:command Create a new command
```

#### This PR

```console
$ ./application

  Application  unreleased

  USAGE: application <command> [options] [arguments]

  projects     [p] List all running projects

  app:build    Build a single file executable
  app:install  Install optional components
  app:rename   Set the application name

  make:command Create a new command
```

### Risks

This PR does not modify the list of commands used internally. It only modifies how the commands are displayed in the `USAGE` note when running `./application`. Therefore if any bugs were to be introduced by this PR, it would be limited to the `USAGE` notes of the `./application` command and not to any functionality.

When running `unique()` there's no risk of combining commands with the same name under different namespaces because `$command->getName()` includes namespaces (e.g. commands `install` and `app:install` would not be combined).

### Laravel Artisan

In comparison Laravel uses Symfony's console component for listing commands with artisan. Symfony console component displays aliases similar to this PR ([see source](https://github.com/symfony/console/blob/5.x/Descriptor/TextDescriptor.php#L221-L273)).

---

🙏 Possible to add `hacktoberfest-accepted` label to this PR? ([Details](https://hacktoberfest.digitalocean.com/details#maintainers))