### PR TITLE
fix usort causing error with PHP8

### DIFF
--- a/src/Describer.php
+++ b/src/Describer.php
@@ -107,7 +107,7 @@ class Describer implements DescriberContract
             $commands = $commands->toArray();
 
             usort($commands, function ($a, $b) {
-                return $a->getName() > $b->getName();
+                return strcmp($a->getName(), $b->getName());
             });
 
             foreach ($commands as $command) {


### PR DESCRIPTION
This makes the library compatible with PHP8 without any change in how the table commands are shown.