### PR TITLE
chore(deps): update to require Laravel 9 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/console": "^7.0|^8.0|^9.0",
-        "illuminate/support": "^7.0|^8.0|^9.0"
+        "php": "^8.1",
+        "illuminate/console": "^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This updates to require Laravel 9 or later, and PHP 8.1 or later.