### PR TITLE
Rename config publishing group to match the filename

### DIFF
--- a/src/LaravelConsoleSummaryServiceProvider.php
+++ b/src/LaravelConsoleSummaryServiceProvider.php
@@ -28,7 +28,7 @@ class LaravelConsoleSummaryServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/config.php' => config_path('laravel-console-summary.php'),
-        ], 'config');
+        ], 'laravel-console-summary-config');
 
         $this->commands(SummaryCommand::class);
     }


### PR DESCRIPTION
Changes the group name used when running `php artisan vendor:publish` so be more descriptive of what it publishes.

Fixes https://github.com/nunomaduro/laravel-console-summary/issues/17